### PR TITLE
Return `ULONG_MAX` on HC-SR04 error

### DIFF
--- a/lib/arduino/rcc/library.properties
+++ b/lib/arduino/rcc/library.properties
@@ -1,5 +1,5 @@
 name=Cooper Union Summer STEM - Robotics Crash Course
-version=0.2.2
+version=1.0.0
 author=Michael Giglia <michael.a.giglia@gmail.com>, Andrew Lorber <andrewlorber@aol.com>, Jacob Koziej <jacobkoziej@gmail.com>
 maintainer=Michael Giglia <michael.a.giglia@gmail.com>
 sentence=Helper library for the Robotics Crash Course.


### PR DESCRIPTION
The following is done to make using the HC-SR04 more intuitive if an object is far enough away to timeout.